### PR TITLE
Compatibility with traceur

### DIFF
--- a/co-mocha.js
+++ b/co-mocha.js
@@ -9,8 +9,11 @@ var run      = Runnable.prototype.run;
  * @param {Function} fn
  */
 Runnable.prototype.run = function (fn) {
-  if (this.fn.constructor.name === 'GeneratorFunction') {
-    this.fn   = co(this.fn);
+  var result = this.fn();
+
+  if (typeof(result.next) == 'function' &&
+      typeof(result.throw) == 'function') {
+    this.fn   = co(result);
     this.sync = !(this.async = true);
   }
 


### PR DESCRIPTION
The generator functions that traceur creates aren't really generators, they're just plain functions. The check `this.fn.constructor.name === 'GeneratorFunction'` doesn't work. This change makes it work even for them. Sure it's not as nice (3 lines more) but I think it's worth it.
