### PR TITLE
Traceur compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Enable support for generators in Mocha tests using [co](https://github.com/visionmedia/co).
 
-Currently you must use the `--harmony-generators` flag when running node 0.11.x to get access to generators.
+Currently you must either use the `--harmony-generators` flag when running node 0.11.x to get access to generators or transpile your tests using traceur.
 
 ## Installation
 
@@ -14,11 +14,17 @@ npm install co-mocha --save-dev
 
 Add `--require co-mocha` to your `mocha.opts`. Now you can write your tests using generators.
 
+Alternatively you can also just `require('co-mocha')` in your test file.
+
 ```js
 it('should do something', function* () {
   yield users.load(123);
 });
 ```
+
+## How it works
+
+`co-mocha` interally overwrites mocha's `Runnable.prototype.run`. In contrast to the other npm package `mocha-co` it isn't a mocha fork but just extends mocha's functionality.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "istanbul": "git://github.com/gotwarlost/istanbul#harmony"
   },
   "dependencies": {
-    "co": "3.x"
+    "co": "3.x",
+    "rsvp": "^3.0.6"
   },
   "peerDependencies": {
     "mocha": "1.x"


### PR DESCRIPTION
What about this solution? :)

I tried it out and it works for
- Async `function(done) { ... done(); }`
- Promise `function() { ... return promise; }`
- Sync `function() { ... }`
- Generator `function*() { ... }`

I'm not sure if this can be done that cleanly without a promise lib. If you don't mind having RSVP as a dep I think this is a great solution.

~~Don't merge it yet, still want to try something out...~~
Can't think of a better solution. If you find one and don't merge this PR it's fine with me, too. I really only care about that it somehow becomes compatible with traceur. The other package `mocha-co` is compatible with traceur, but I don't like that it's a complete mocha fork.
