### PR TITLE
Add ES6 transpiler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Enable support for generators in Mocha tests using [co](https://github.com/visionmedia/co).
 
-Currently you must use the `--harmony-generators` flag when running node 0.11.x to get access to generators.
+Use the `--harmony-generators` flag when running node 0.11.x to access generator functions, or transpile your tests using [traceur](https://github.com/google/traceur-compiler) or [regenerator](https://github.com/facebook/regenerator).
 
 ## Installation
 

--- a/co-mocha.js
+++ b/co-mocha.js
@@ -1,7 +1,9 @@
-var co       = require('co');
-var mocha    = require('mocha');
-var Runnable = mocha.Runnable;
-var run      = Runnable.prototype.run;
+var co          = require('co');
+var mocha       = require('mocha');
+var isPromise   = require('is-promise');
+var isGenerator = require('is-generator');
+var Runnable    = mocha.Runnable;
+var run         = Runnable.prototype.run;
 
 /**
  * Override the Mocha function runner and enable generator support with co.
@@ -9,10 +11,27 @@ var run      = Runnable.prototype.run;
  * @param {Function} fn
  */
 Runnable.prototype.run = function (fn) {
-  if (this.fn.constructor.name === 'GeneratorFunction') {
-    this.fn   = co(this.fn);
-    this.sync = !(this.async = true);
-  }
+  var func = this.fn;
+  var sync = this.sync;
 
+  // Flip the async switch to always have a callback function provided.
+  this.sync = !(this.async = true);
+
+  // Override the function to provide a special generator handler.
+  this.fn = function (done) {
+    var result = sync ? func() : func(done);
+
+    if (isGenerator(result)) {
+      return co(result)(done);
+    }
+
+    if (isPromise(result)) {
+      return result.then(function () {
+        return done();
+      }, done);
+    }
+
+    return sync && done();
+  };
   return run.call(this, fn);
 };

--- a/package.json
+++ b/package.json
@@ -23,11 +23,16 @@
   },
   "homepage": "https://github.com/blakeembrey/co-mocha",
   "devDependencies": {
-    "mocha": "~1.17.0",
-    "istanbul": "git://github.com/gotwarlost/istanbul#harmony"
+    "bluebird": "^1.2.4",
+    "istanbul": "git://github.com/gotwarlost/istanbul#harmony",
+    "mocha": "^1.18.2",
+    "regenerator": "^0.4.7",
+    "traceur": "0.0.39"
   },
   "dependencies": {
-    "co": "3.x"
+    "co": "3.x",
+    "is-generator": "0.0.4",
+    "is-promise": "^1.0.0"
   },
   "peerDependencies": {
     "mocha": "1.x"

--- a/test.js
+++ b/test.js
@@ -1,6 +1,8 @@
 /* global describe, it */
 
-var assert = require('assert');
+var traceur     = require('traceur');
+var Promise     = require('bluebird');
+var regenerator = require('regenerator');
 
 /**
  * Wait a certain amount of time before proceeding to the callback.
@@ -23,17 +25,84 @@ describe('co-mocha', function () {
     yield wait(100);
   });
 
-  it('should work synchronously', function () {
-    assert.equal(1 + 1, 2);
+  it('should work synchronously', function () {});
+
+  it('should error synchronously', function () {
+    throw new Error('You had one job');
   });
 
-  it('should work with generators', function* () {
-    assert.equal(1 + 1, 2);
-    yield wait(100);
+  it('should work with promises', function () {
+    return new Promise(function (resolve) {
+      return wait(100)(resolve);
+    });
   });
 
-  it('should work with with callbacks', function (done) {
-    assert.equal(1 + 1, 2);
-    wait(100)(done);
+  it('should error with promises', function () {
+    return new Promise(function (resolve, reject) {
+      return wait(100)(function () {
+        return reject(new Error('You promised me'));
+      });
+    });
+  });
+
+  it('should work with callbacks', function (done) {
+    return wait(100)(done);
+  });
+
+  it('should error with callbacks', function (done) {
+    return wait(100)(function () {
+      return done(new Error('You never called me back'));
+    });
+  });
+
+  describe('generators', function () {
+    /**
+     * String version of generator based test. This will be used to compile for
+     * testing different ES6 to ES5 transpilers.
+     *
+     * @type {Array}
+     */
+    var testSource = [
+      '(function* () {',
+      '  yield wait(100);',
+      '});'
+    ].join('\n');
+
+    var testErrorSource = [
+      '(function* () {',
+      '  yield wait(100);',
+      '  throw new Error(\'This generation has failed\');',
+      '});'
+    ].join('\n');
+
+    it(
+      'should work with es6 generators',
+      eval(testSource)
+    );
+
+    it(
+      'should error with es6 generators',
+      eval(testErrorSource)
+    );
+
+    it(
+      'should work with regenerator generators',
+      eval(regenerator(testSource, { includeRuntime: true }))
+    );
+
+    it(
+      'should error with regenerator generators',
+      eval(regenerator(testErrorSource, { includeRuntime: true }))
+    );
+
+    it(
+      'should work with traceur generators',
+      eval(traceur.compile(testSource).js)
+    );
+
+    it(
+      'should error with traceur generators',
+      eval(traceur.compile(testErrorSource).js)
+    );
   });
 });


### PR DESCRIPTION
- All the special casing is to support traceur, regenerator already does the right thing
- Add promise tests
- Add transpiler tests
- Add purposely failing tests to ensure errors are correctly emitted
