### PR TITLE
Bump mocha peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "is-generator": "^1.0.0"
   },
   "peerDependencies": {
-    "mocha": ">=1.18 <2"
+    "mocha": ">=1.18 <3"
   }
 }


### PR DESCRIPTION
`2.1` is kind of arbitrary, so feel free to suggest whatever you think would be the right constraint here.
