### PR TITLE
Look at global module cache rather than just main scripts immediate loads

### DIFF
--- a/co-mocha.js
+++ b/co-mocha.js
@@ -40,7 +40,7 @@ var coMocha = module.exports = function (mocha) {
  */
 var findNodeJSMocha = function () {
   var suffix   = path.sep + path.join('', 'mocha', 'index.js');
-  var children = require('module')._cache || {};
+  var children = require.cache || {};
 
   return Object.keys(children).filter(function (child) {
     return child.slice(suffix.length * -1) === suffix;


### PR DESCRIPTION
I wanted to use this with `gulp-mocha` so patched it to look at the global list of loaded modules rather than just `require.main`.
