### PR TITLE
chore: support mocha v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "is-generator": "^1.0.1"
   },
   "peerDependencies": {
-    "mocha": ">=1.18 <3"
+    "mocha": ">=1.18 <4"
   }
 }


### PR DESCRIPTION
Mocha v3.0.0 is out, support everything less than v4 and forget about trying to support prerelease versions.