### PR TITLE
Wildcard `mocha` dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "chai": "^3.0.0",
     "es6-promise": "^4.0.5",
     "istanbul": "^1.1.0-alpha.1",
-    "mocha": "^3.1.2",
+    "mocha": "*",
     "regenerator": "^0.9.0",
     "standard": "^10.0.0",
     "testem": "^1.13.0",


### PR DESCRIPTION
Fixes an issue with NPM exiting with `1` when installing older `mocha` versions.