### PR TITLE
Add support for mocha v5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   - MOCHA=mocha@2
   - MOCHA=mocha@3
   - MOCHA=mocha@4
+  - MOCHA=mocha@5
 
 node_js:
   - "0.10"
@@ -25,6 +26,8 @@ node_js:
 matrix:
   exclude:
   - env: MOCHA=mocha@4
+    node_js: "0.10"
+  - env: MOCHA=mocha@5
     node_js: "0.10"
 
 after_script: "npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "is-generator": "^1.0.1"
   },
   "peerDependencies": {
-    "mocha": ">=1.18 <5"
+    "mocha": ">=1.18 <6"
   }
 }


### PR DESCRIPTION
Hi, @blakeembrey!
mocha-5.0.0 was released (https://github.com/mochajs/mocha/releases/tag/v5.0.0) and co-mocha works fine with mocha-5.
Would you mind adding mocha-5 support?